### PR TITLE
Add "or" operator handler for refine filters

### DIFF
--- a/src/dataProvider.ts
+++ b/src/dataProvider.ts
@@ -52,18 +52,24 @@ const generateFilter = (filters?: CrudFilters) => {
     let search: string='';
     if (filters) {
         queryFilters['_and'] = [];
-        filters.map(({ field, operator, value }) => {
-            if (value) {
-                if (field === "search") {
-                    search = value;
-                }
-                else {
-                    const directusOperator = operators[operator];
-                    let queryField = `${field}.${directusOperator}`;
-                    let filterObj = strToObj(queryField, value);
+        filters.map((filter) => {
+            if (filter.operator !== "or") {
+                const {field, operator, value} = filter;
 
-                    queryFilters['_and'].push(filterObj);
+                if (value) {
+                    if (field === "search") {
+                        search = value;
+                    }
+                    else {
+                        const directusOperator = operators[operator];
+                        let queryField = `${field}.${directusOperator}`;
+                        let filterObj = strToObj(queryField, value);
+
+                        queryFilters['_and'].push(filterObj);
+                    }
                 }
+            } else {
+                // TODO: implement "or" operator filters for directus
             }
         });
     }


### PR DESCRIPTION
Hey @tspvivek,

refine will soon release a version that will add support for the `or` operator for filtering. With the new version, `CrudFilters` will consist of two separate union types, so the `generateFilter` function will need to handle these two types.

The user will can create a filter as follows:

```ts
filter = [
    {
      operator: "eq",
      field: "age",
      value: 20
    },
    {
      operator: "or",
      value: [
        {
          field: "title",
          operator: "eq",
          value: "Test",
        },
        {
          field: "description",
          operator: "eq",
          value: "Test"
        }
      ]
   }
]
```

Here the query would look like `"age" == 20 AND ("title" == "Test" OR "description" == "Test")`

The `field` property will can be undefined so I made a small change to the your `genereteFilter` function. When refine releases the new version, you can make some changes on this PR to add "or" operator support.

You can check out the [PR](https://github.com/pankod/refine/pull/1598) for more information about the new release.

Happy coding!
