### PR TITLE
Fix pagination not working with PK other than "id"

### DIFF
--- a/package/src/dataProvider.ts
+++ b/package/src/dataProvider.ts
@@ -194,7 +194,7 @@ export const dataProvider = (directusClient: any): DataProvider => ({
 
             return {
                 data: response,
-                total: total[0]?.countDistinct?.id ?? 0,
+                total: total[0]?.countDistinct?.[aggregateField] ?? 0,
             };
         } catch (e) {
             console.log(e);


### PR DESCRIPTION
When you return the data in [`getList`](https://github.com/tspvivek/refine-directus/blob/master/package/src/dataProvider.ts#L197), you do:

```ts
// ...
const aggregateField = meta?.aggregateField ? meta.aggregateField : "id";

const total = await directusClient.request(
    aggregate(resource, {
        query: params,
        aggregate: {
            countDistinct: aggregateField,
        },
    })
);

return {
    data: response,
    total: total[0]?.countDistinct?.id ?? 0,
};
```

You correctly use `aggregateField` from `meta` when calling `aggregate` but you forgot to use it again in the `return` statement, so basically pagination won't work with PK other than "id".

This PR solve the issue.